### PR TITLE
Update README.md. The top level `pub` command is deprecated. Use `dar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ to enable arb_utils to be globally activated.
 To easily sort an arb and update original file, use
 
 ```sh
-pub global run arb_utils:sort <INPUT FILE>
+dart pub global run arb_utils:sort <INPUT FILE>
 ```
 
 where `<INPUT FILE>` is a path to the input file.
@@ -269,7 +269,7 @@ Also, there are 3 flags for different sorting.
 For example, to sort with case insensitive and in descending order, use
 
 ```sh
-pub global run arb_utils:sort -i -d <INPUT FILE>
+dart pub global run arb_utils:sort -i -d <INPUT FILE>
 ```
 
 ##### Add Missing Default Metadata
@@ -277,7 +277,7 @@ pub global run arb_utils:sort -i -d <INPUT FILE>
 To easily add missing metadata to an arb and update original file, use
 
 ```sh
-pub global run arb_utils:generate_meta <INPUT FILE>
+dart pub global run arb_utils:generate_meta <INPUT FILE>
 ```
 
 where `<INPUT FILE>` is a path to the input file.


### PR DESCRIPTION
The top level `pub` command is deprecated. Use `dart pub` instead.
https://github.com/Dart-Code/Dart-Code/issues/2944